### PR TITLE
Fix broken links

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -7,10 +7,10 @@ let baseUrl
 if (!process.browser) {
   baseUrl =
     process.env.NODE_ENV === 'development'
-      ? 'https://api.linklet.ml/api'
-      : 'https://api.linklet.ml/api'
+      ? 'https://linklet.ml/api'
+      : 'https://linklet.ml/api'
 } else {
-  baseUrl = 'https://api.linklet.ml/api'
+  baseUrl = 'https://linklet.ml/api'
 }
 
 const getAll = ({ page = 1, search, myLinks, req, bookmarks, sort } = {}) => {


### PR DESCRIPTION
`https://api.linklet.ml/api` is broken. Only way to run locally is using `https://linklet.ml/api` (like the deployed version). 